### PR TITLE
Update version of lnd to 0.9.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR $GOPATH/src/github.com/lightningnetwork/lnd
 RUN git config --global user.email "tkp@kirkdesigns.co.uk" \
   && git config --global user.name "Tom Kirkpatrick" \
   && git clone https://github.com/lightningnetwork/lnd . \
-  && git reset --hard v0.8.0-beta \
+  && git reset --hard v0.9.0-beta \
   && make \
   && make install tags="experimental monitoring autopilotrpc chainrpc invoicesrpc routerrpc signrpc walletrpc watchtowerrpc wtclientrpc" \
   && cp /go/bin/lncli /bin/ \


### PR DESCRIPTION
As of January 22, 2020, the latest version of `lnd` is `0.9.0-beta`. This pull request updates the version of `lnd` used when building from source.

`0.9.0` Release:
https://github.com/lightningnetwork/lnd/releases/tag/v0.9.0-beta

