### PR TITLE
Update lndconnect to version 0.2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN git config --global user.email "tkp@kirkdesigns.co.uk" \
 # Grab and install the latest version of lndconnect.
 WORKDIR $GOPATH/src/github.com/LN-Zap/lndconnect
 RUN git clone https://github.com/LN-Zap/lndconnect . \
-  && git reset --hard b20ee064b02307f74782f9d84169bb4a4a8d3a10 \
+  && git reset --hard v0.2.0 \
   && make \
   && make install \
   && cp /go/bin/lndconnect /bin/


### PR DESCRIPTION
It appears that the `lndconnect` repository has been updated since this revision. It also appears that the repository uses releases as well. This PR updates `lndconnect` and also uses a versioned release instead of a git sha.

0.2.0 Release:
https://github.com/LN-Zap/lndconnect/releases/tag/v0.2.0