### PR TITLE
Stop printing startup commands to stderr

### DIFF
--- a/bin/lnd_init
+++ b/bin/lnd_init
@@ -1,6 +1,5 @@
 #!/bin/bash
-
-set -ex
+set -e
 
 # This shouldn't be in the Dockerfile or containers built from the same image
 # will have the same credentials.

--- a/bin/lnd_oneshot
+++ b/bin/lnd_oneshot
@@ -1,6 +1,5 @@
 #!/bin/bash
-
-set -ex
+set -e
 
 # Generate lnd.conf
 lnd_init

--- a/bin/unlock
+++ b/bin/unlock
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 # Do nothing if the PASSWORD var is not set.
 if [ -z "$PASSWORD" ]; then
@@ -11,12 +12,6 @@ if [ -z "$RESTPORT" ]; then
   echo "[lnd_unlock] Please set RESTPORT in order to unlock wallet automatically."
   exit 1
 fi
-
-# output script content for easier debugging.
-# set -x
-
-# exit from script if error was raised.
-set -e
 
 # return is used within bash function in order to return the value.
 return() {


### PR DESCRIPTION
When the container starts up it prints some of the commands that are running to stderr. This causes errors to appear in our logs, which we don't want.

![image](https://user-images.githubusercontent.com/200251/113279530-80bc7d00-92e3-11eb-85c3-146642c90d4a.png)

Remove `set -x` which was only added for debugging purposes and is the cause of some of the errors reported at container startup time
